### PR TITLE
Update zhheoblog.css

### DIFF
--- a/templates/assets/zhheo/zhheoblog.css
+++ b/templates/assets/zhheo/zhheoblog.css
@@ -1325,6 +1325,19 @@ blockquote footer cite::before {
     transition: all 0.3s ease 0s;
 }
 
+/*友链及在线工具卡片的自适应宽度设置 */
+.flink-list{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+}
+
+.flink-list > .flink-list-item{
+    flex: 0 0 30%;
+    min-width: 280px;
+    max-width: 310px;
+}
+
 .flink#article-container .flink-list.mini > .flink-list-item {
     height: 60px;
 }


### PR DESCRIPTION
友链及在线工具卡片的自适应宽度设置 #731 
左右未鼠标悬停效果，中间鼠标悬停效果保持原样
![image](https://github.com/chengzhongxue/halo-theme-hao/assets/77838031/fa9c2c43-dfa4-4c2b-a3bc-f2741669c34c)
使用Iphone se界面如下：
![image](https://github.com/chengzhongxue/halo-theme-hao/assets/77838031/c23e1357-c2b8-4c72-8835-3fb82caa12fd)


