### PR TITLE
fix: 修复云服务商图片导致的底部闪烁问题

### DIFF
--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -125,7 +125,7 @@
                    rel="noopener external nofollow noreferrer noopener"
                    target="_blank">
                     <span>本网站由</span>&nbsp;&nbsp;
-                    <img th:src="${assets_link + '/images/footer/upyun-5.png'}" alt="upyun" class="entered loading cloud" />
+                    <img th:src="${assets_link + '/images/footer/upyun-5.png'}" alt="upyun" class="cloud-logo" />
                     &nbsp;&nbsp;<span>提供CDN加速/云存储服务</span>
                 </a>
                 <!-- 阿里云 -->
@@ -134,7 +134,7 @@
                    rel="noopener external nofollow noreferrer noopener"
                    target="_blank">
                     <span>本网站由</span>&nbsp;&nbsp;
-                    <img th:src="${assets_link + '/images/footer/aliyun.png'}" alt="aliyun_cloud" class="entered loading cloud" />
+                    <img th:src="${assets_link + '/images/footer/aliyun.png'}" alt="aliyun_cloud" class="cloud-logo" />
                     &nbsp;&nbsp;<span>提供CDN加速/云存储服务</span>
                 </a>
                 <!-- 腾讯云 -->
@@ -143,7 +143,7 @@
                    rel="noopener external nofollow noreferrer noopener"
                    target="_blank">
                     <span>本网站由</span>&nbsp;&nbsp;
-                    <img th:src="${assets_link + '/images/footer/tencent.png'}" alt="tencent_cloud" class="entered loading cloud" />
+                    <img th:src="${assets_link + '/images/footer/tencent.png'}" alt="tencent_cloud" class="cloud-logo" />
                     &nbsp;&nbsp;<span>提供CDN加速/云存储服务</span>
                 </a>
                 <!-- 华为云 -->
@@ -152,7 +152,7 @@
                    rel="noopener external nofollow noreferrer noopener"
                    target="_blank">
                     <span>本网站由</span>&nbsp;&nbsp;
-                    <img th:src="${assets_link + '/images/footer/huawei.png'}" alt="huawei_cloud" class="entered loading cloud" />
+                    <img th:src="${assets_link + '/images/footer/huawei.png'}" alt="huawei_cloud" class="cloud-logo" />
                     &nbsp;&nbsp;<span>提供CDN加速/云存储服务</span>
                 </a>
                 <!-- 自定义云服务信息 -->
@@ -161,7 +161,7 @@
                    rel="noopener external nofollow noreferrer noopener"
                    target="_blank">
                     <span>本网站由</span>&nbsp;&nbsp;
-                    <img th:src="@{${theme.config.footer.footerContent.default_enable_group.yunzhichi_url}}" alt="custom_cloud" class="entered loading cloud"/>
+                    <img th:src="@{${theme.config.footer.footerContent.default_enable_group.yunzhichi_url}}" alt="custom_cloud" class="cloud-logo"/>
                     &nbsp;&nbsp;<span>提供CDN加速/云存储服务</span>
                 </a>
                 
@@ -218,7 +218,7 @@
             display: flex;
             align-items: center;
         }
-        img.entered.loading.cloud {
+        img.cloud-logo {
             height: 32px;
         }
     </style>


### PR DESCRIPTION
所有云服务商的图片都使用了硬编码的 class="entered loading cloud"，这与主题的懒加载系统（vanilla-lazyload）产生了冲突